### PR TITLE
Add finc/kustomize orb

### DIFF
--- a/kustomize/README.md
+++ b/kustomize/README.md
@@ -1,0 +1,32 @@
+### publish development version
+
+```
+cd kustomize
+
+DEV_VERSION=awesome_command
+
+circleci orb validate ./orb.yaml
+circleci orb publish ./orb.yaml finc/kustomize@dev:$DEV_VERSION
+circleci orb info finc/kustomize@dev:$DEV_VERSION
+```
+
+### test
+
+Your `.circleci/config.yml`
+
+```yaml
+orbs:
+  kustomize: finc/kustomize@dev:awesome_command
+
+# ... Use orb and test
+```
+
+
+### promote dev version
+
+promote `dev:awesome_command` version and bump patch version
+
+```
+circleci orb publish promote finc/kustomize@dev:awesome_command patch
+```
+

--- a/kustomize/orb.yaml
+++ b/kustomize/orb.yaml
@@ -1,0 +1,37 @@
+# orb name: finc/kustomize
+version: 2.1
+description: "Install kustomize"
+
+commands:
+  install:
+    description: "Install kustomize(v3.8.1 by default)"
+    parameters:
+      version:
+        type: string
+        default: "v3.8.1"
+        description: "Please see release page: https://github.com/kubernetes-sigs/kustomize/releases"
+    steps:
+      - run:
+          name: "Install kustomize"
+          command: |
+            URL=https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/<< parameters.version >>/kustomize_<< parameters.version >>_linux_amd64.tar.gz
+            curl -L $URL | tar zx
+
+            [ -w /usr/local/bin ] && SUDO="" || SUDO=sudo
+            $SUDO chmod +x ./kustomize
+            $SUDO mv ./kustomize /usr/local/bin
+
+examples:
+  install:
+    description: "install kustomize"
+    usage:
+      version: 2.1
+      orbs:
+        kustomize: finc/kustomize@0.0.1
+      jobs:
+        build:
+          docker:
+            - image: circleci/golang:1.15
+          steps:
+            - kustomize/install
+


### PR DESCRIPTION
# Summary

kustomizeをinstallするためのorbを作った。
既に [finc/kustomize@0.0.1](https://circleci.com/orbs/registry/orb/finc/kustomize) としてrelease済みです。

### Usage

See: https://circleci.com/orbs/registry/orb/finc/kustomize

