### PR TITLE
Fix k8s orb bugs

### DIFF
--- a/k8s/orb.yaml
+++ b/k8s/orb.yaml
@@ -129,7 +129,7 @@ commands:
       - run:
           name: "DB migration"
           command: |
-            cd .circleci
+            cd $CIRCLE_WORKING_DIRECTORY/.circleci
 
             K8S_NAMESPACE="<< parameters.namespace >>"
 

--- a/k8s/orb.yaml
+++ b/k8s/orb.yaml
@@ -159,7 +159,7 @@ commands:
           name: "Clean up migration job resource"
           when: always
           command: |
-            kubectl delete jobs.batch -n "<< parameters.namespace >>" db-migration
+            kubectl delete --ignore-not-found jobs.batch -n "<< parameters.namespace >>" db-migration
 
 examples:
   rollback-deployment-on-fail:


### PR DESCRIPTION
# Summary

finc/k8s orbの以下のバグを修正。

- DB migration時に .circleciが相対パスで指定されているため、特定のパスでしか動作しないバグを修正。
- DB migration時のcleanup stepでmigration jobが存在しない場合エラーになってしまうバグを修正。
  - --ignore-not-found flagを追加することによって存在しない場合でもエラーにならないようにした

