### PR TITLE
print log, events, kustomize, describe

### DIFF
--- a/k8s/CHANGELOG.md
+++ b/k8s/CHANGELOG.md
@@ -14,9 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Print infomation on fail. It's contains event, pod describe and executed manfest.
+- Print information on fail. It contains events, pod description and executed manifest.
 
 ### Fixed
 
 - Log is not output on DB migration failure.
-

--- a/k8s/CHANGELOG.md
+++ b/k8s/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+
+### Added
+
+- canary release
+
+## [0.0.9] - 2020-12-03
+
+### Added
+
+- Print infomation on fail. It's contains event, pod describe and executed manfest.
+
+### Fixed
+
+- Log is not output on DB migration failure.
+

--- a/k8s/orb.yaml
+++ b/k8s/orb.yaml
@@ -150,12 +150,36 @@ commands:
             kubectl wait -n "<< parameters.namespace >>" --for=condition=failed   --timeout=30m job/db-migration && exit 1 & failure_pid=$!
             wait -n $completion_pid $failure_pid
 
+      - run:
+          name: "Print migration logs"
+          when: always
+          command: |
             for pod in $(kubectl get pod -n "<< parameters.namespace >>" -l "finc.com/migration-pod-for=<< parameters.migration-pod-for >>" --no-headers -o custom-columns=":metadata.name"); do
               echo "------------------------------------------------------------"
               echo "[$pod] Migration log"
               echo "------------------------------------------------------------"
               kubectl logs -n "<< parameters.namespace >>" "$pod"
             done
+
+      - run:
+          name: "Print debug logs (kustomize build / events / describe pod)"
+          when: on_fail
+          command: |
+            echo "------------------------------------------------------------"
+            echo "Result of kustomize build"
+            echo "------------------------------------------------------------"
+            kustomize build .circleci
+
+            echo "------------------------------------------------------------"
+            echo "kubectl get events"
+            echo "------------------------------------------------------------"
+            kubectl get events -n "<< parameters.namespace >>" --sort-by=.metadata.creationTimestamp | grep db-migration
+
+            echo "------------------------------------------------------------"
+            echo "kubectl describe pod"
+            echo "------------------------------------------------------------"
+            kubectl describe pod -n "<< parameters.namespace >>" -l "finc.com/migration-pod-for=<< parameters.migration-pod-for >>"
+
       - run:
           name: "Clean up migration job resource"
           when: always


### PR DESCRIPTION
# やったこと
migration時のlogを出力するようにした
失敗時にevents/kustomize/describeを出力するようにした
成功例 (rolloutのタイミングでcancelしているけどmigrationは成功している)
https://app.circleci.com/pipelines/github/FiNCDeveloper/requl_mobile/1357/workflows/36dc8420-c883-45f7-8657-e7c2fe77da72/jobs/22528
失敗例
https://app.circleci.com/pipelines/github/FiNCDeveloper/requl_mobile/1359/workflows/3d683fb8-d876-4736-8eda-08711548c497/jobs/22530

# promote-from-devはまだ未実施


append sho2010
Resolve #8