### PR TITLE
Multiple deployment updates and rollback

### DIFF
--- a/k8s/orb.yaml
+++ b/k8s/orb.yaml
@@ -138,7 +138,7 @@ commands:
           name: "Update container images"
           description: "Update container images by using the `kubectl set image`. Filter given container names before updating deployment images."
           command: |
-            container_image_updates=($(echo "<< parameters.container-image-updates >>" | awk '{cnt=split($0, res, " ");for (i=1;i<=cnt;i++) print res[i]}'))
+            container_image_updates=($(echo "<< parameters.container-image-updates >>"))
 
             DRY_RUN="<< parameters.dry-run >>"
 
@@ -148,14 +148,14 @@ commands:
               echo "============================================================"
               echo "deployment: $dep"
               echo "============================================================"
-              # Build a new container_name=image_name pairs from the provided values to match the container image names in the target deployment resource.
+              # Build a new container_name=image pairs from the provided values to match the container image names in the target deployment resource.
               pod_spec=$(kubectl get --namespace=$__FINC_K8S_NAMESPACE deployment/$dep -o jsonpath --template {.spec.template.spec})
 
-              for container in ${container_image_updates[@]}; do
-                image_name=$(echo $container | awk -F ':' '{ print $1 }')
-                container_name=$(echo $pod_spec | jq -r --arg image_name $image_name '.containers[] | select(.image | startswith($image_name)) | .name')
+              for image in ${container_image_updates[@]}; do
+                repository=$(echo $image | awk -F ':' '{ print $1 }')
+                container_name=$(echo $pod_spec | jq -r --arg repository $repository '.containers[] | select(.image | startswith($repository)) | .name')
                 if [ -n "$container_name" ]; then
-                  set -- "$@" "${container_name}=${container}"
+                  set -- "$@" "${container_name}=${image}"
                 fi
               done
 

--- a/k8s/orb.yaml
+++ b/k8s/orb.yaml
@@ -191,7 +191,7 @@ commands:
 
               if [ -z "$rev" ]; then
                 echo "[WARN] unknown before revision"
-                exit
+                continue
               fi
 
               CURRENT_REVISION=$(kubectl get -n "$__FINC_K8S_NAMESPACE" "$target" -o=jsonpath='{.metadata.annotations.deployment\.kubernetes\.io/revision}')

--- a/k8s/orb.yaml
+++ b/k8s/orb.yaml
@@ -325,6 +325,8 @@ examples:
 
   rollback-deployment-on-fail:
     description: |
+      (Deprecated) Consider to use update-container-images.
+
       rollback deployment revision if deploy fail.
 
       Requirements:

--- a/k8s/orb.yaml
+++ b/k8s/orb.yaml
@@ -354,7 +354,7 @@ examples:
 
   db-migration:
     description: |
-      rollback deployment revision if deploy fail.
+      DB migration from kubernetes job.
 
       Requirements:
       - kubeconfig should be configured to connect to the cluster.

--- a/k8s/orb.yaml
+++ b/k8s/orb.yaml
@@ -97,7 +97,8 @@ commands:
         default: ""
       dry-run:
         description: |
-          Specify dry-run strategy
+          Specify the dry-run strategy that the `kubectl set image` command will be executed with.
+          See: https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#-em-image-em-
         type: enum
         enum: ["none", "client", "server"]
         default: "none"

--- a/k8s/orb.yaml
+++ b/k8s/orb.yaml
@@ -303,6 +303,26 @@ commands:
             kubectl delete --ignore-not-found jobs.batch -n "<< parameters.namespace >>" db-migration
 
 examples:
+  deployment-update-and-rollback-on-fail:
+    description: |
+      Update kubernetes resource.
+      Rollback deployment revision if deploy fail.
+    usage:
+      version: 2.1
+      orbs:
+        finc-k8s: finc/k8s@x.y.z
+        k8s: circleci/kubernetes@x.y.z
+      jobs:
+        build:
+          docker:
+            - image: circleci/golang:x.y
+          steps:
+            - finc-k8s/update-container-images:
+                container-image-updates: example1=example1:latest example2=example2:latest
+                namespace: example
+                watch-timeout: 5m
+                deployment-target: stable
+
   rollback-deployment-on-fail:
     description: |
       rollback deployment revision if deploy fail.

--- a/k8s/orb.yaml
+++ b/k8s/orb.yaml
@@ -86,7 +86,8 @@ commands:
       container-image-updates:
         type: string
         description: |
-          Specify a list of container image updates
+          Specify a list of container image updates in the space-delimited format.
+          (e.g. container1:latest nginx:1.9.1)
       namespace:
         type: string
         description: |
@@ -137,7 +138,7 @@ commands:
           name: "Update container images"
           description: "Update container images by using the `kubectl set image`. Filter given container names before updating deployment images."
           command: |
-            CONTAINER_IMAGE_UPDATES="<< parameters.container-image-updates >>"
+            container_image_updates=($(echo "<< parameters.container-image-updates >>" | awk '{cnt=split($0, res, " ");for (i=1;i<=cnt;i++) print res[i]}'))
 
             DRY_RUN="<< parameters.dry-run >>"
 
@@ -147,15 +148,21 @@ commands:
               echo "============================================================"
               echo "deployment: $dep"
               echo "============================================================"
-              # Build a new container_name=image_name pairs from the provided values to match the container names in the target deployment resource.
-              container_names=($(echo $(kubectl get -n $__FINC_K8S_NAMESPACE deployment/$dep -o json | jq -r '.spec.template.spec.containers[] | .name')))
-              regexpr=$(IFS='|'; echo "${container_names[*]}")
-              target_container_images=($(echo $CONTAINER_IMAGE_UPDATES | awk '{cnt=split($0, res, " ");for (i=1;i<=cnt;i++) print res[i]}' | awk '/'"${regexpr}"'/ { print }'))
+              # Build a new container_name=image_name pairs from the provided values to match the container image names in the target deployment resource.
+              pod_spec=$(kubectl get --namespace=$__FINC_K8S_NAMESPACE deployment/$dep -o jsonpath --template {.spec.template.spec})
+
+              for container in ${container_image_updates[@]}; do
+                image_name=$(echo $container | awk -F ':' '{ print $1 }')
+                container_name=$(echo $pod_spec | jq -r --arg image_name $image_name '.containers[] | select(.image | startswith($image_name)) | .name')
+                if [ -n "$container_name" ]; then
+                  set -- "$@" "${container_name}=${container}"
+                fi
+              done
 
               echo "------------------------------------------------------------"
               echo "set image"
               echo "------------------------------------------------------------"
-              kubectl set image --namespace=$__FINC_K8S_NAMESPACE deployment/$dep $target_container_images --dry-run=$DRY_RUN
+              kubectl set image --namespace=$__FINC_K8S_NAMESPACE deployment/$dep $@ --dry-run=$DRY_RUN
 
               echo "------------------------------------------------------------"
               echo "rollout status"
@@ -166,6 +173,8 @@ commands:
               echo "describe"
               echo "------------------------------------------------------------"
               kubectl describe --namespace=$__FINC_K8S_NAMESPACE deployment/$dep
+
+              set --
             done
       - run:
           when: on_fail
@@ -319,7 +328,7 @@ examples:
             - image: circleci/golang:x.y
           steps:
             - finc-k8s/update-container-images:
-                container-image-updates: example1=example1:latest example2=example2:latest
+                container-image-updates: example1:latest example2:latest
                 namespace: example
                 watch-timeout: 5m
                 deployment-target: stable

--- a/k8s/orb.yaml
+++ b/k8s/orb.yaml
@@ -335,8 +335,6 @@ examples:
 
   rollback-deployment-on-fail:
     description: |
-      (Deprecated) Consider to use update-container-images.
-
       rollback deployment revision if deploy fail.
 
       Requirements:

--- a/k8s/orb.yaml
+++ b/k8s/orb.yaml
@@ -5,6 +5,7 @@ description: "FiNC Technologies kubernetes deploy toolbox"
 orbs:
   kube-orb: circleci/kubernetes@0.11.0
   kustomize: finc/kustomize@0.0.1
+  jq: circleci/jq@2.2.0
 
 commands:
   init-current-revision:
@@ -76,6 +77,121 @@ commands:
               else
                 echo "Did not unnecessary rollback as it. because same revision."
               fi
+
+  update-container-images:
+    description: |
+      Updates existing container images of resources matched with the given target label on the cluster using the `kubectl set image` command.
+      If any of them fails to update then rollback the deployment resources.
+    parameters:
+      container-image-updates:
+        type: string
+        description: |
+          Specify a list of container image updates
+      namespace:
+        type: string
+        description: |
+          The kubernetes namespace that should be used.
+        default: ""
+      watch-timeout:
+        type: string
+        default: ""
+      dry-run:
+        description: |
+          Specify dry-run strategy
+        type: enum
+        enum: ["none", "client", "server"]
+        default: "none"
+      deployment-target:
+        description: "deployment target. enum: 'stable' or 'canary'"
+        type: enum
+        enum: ["stable", "canary"]
+    steps:
+      - jq/install
+      - run:
+          name: "Prepare image update"
+          description: "Get namespace for the later steps."
+          command: |
+            # NOTE:
+            # Naming rule basics: namespace, deployment name is repository name converted to kebab-case.
+            K8S_NAMESPACE="<< parameters.namespace >>"
+            if [ -z "K8S_NAMESPACE" ]; then
+              K8S_NAMESPACE=${CIRCLE_PROJECT_REPONAME//_/-}
+            fi
+            echo "export __FINC_K8S_NAMESPACE=${K8S_NAMESPACE}" >> $BASH_ENV
+      - run:
+          name: "Get current deployment revisons"
+          description: "Fetch deployment current revision from cluster. It's used to deployment rollout undo."
+          command: |
+            DEPLOYMENT_TARGET="<< parameters.deployment-target >>"
+
+            deployments=($(kubectl get -n $__FINC_K8S_NAMESPACE deployment -o=jsonpath='{.items[*].metadata.name}' -l finc.com/canary=${DEPLOYMENT_TARGET}))
+
+            echo "export __FINC_K8S_TARGET_DEPLOYMENTS=(${deployments[@]})" >> $BASH_ENV
+
+            for dep in ${deployments[@]}; do
+              # Deployment resource names are kebab case, so they have to be converted to underscore for the shell arg names.
+              echo "export __FINC_BEFORE_DEPLOYMENT_REVISION_OF_${dep//-/_}=$(kubectl get -n $__FINC_K8S_NAMESPACE deployment/$dep -o=jsonpath='{.metadata.annotations.deployment\.kubernetes\.io/revision}')" >> $BASH_ENV
+            done
+      - run:
+          name: "Update container images"
+          description: "Update container images by using the `kubectl set image`. Filter given container names before updating deployment images."
+          command: |
+            CONTAINER_IMAGE_UPDATES="<< parameters.container-image-updates >>"
+
+            DRY_RUN="<< parameters.dry-run >>"
+
+            WATCH_TIMEOUT="<< parameters.watch-timeout >>"
+
+            for dep in ${__FINC_K8S_TARGET_DEPLOYMENTS[@]}; do
+              echo "============================================================"
+              echo "deployment: $dep"
+              echo "============================================================"
+              # Build a new container_name=image_name pairs from the provided values to match the container names in the target deployment resource.
+              container_names=($(echo $(kubectl get -n $__FINC_K8S_NAMESPACE deployment/$dep -o json | jq -r '.spec.template.spec.containers[] | .name')))
+              regexpr=$(IFS='|'; echo "${container_names[*]}")
+              target_container_images=($(echo $CONTAINER_IMAGE_UPDATES | awk '{cnt=split($0, res, " ");for (i=1;i<=cnt;i++) print res[i]}' | awk '/'"${regexpr}"'/ { print }'))
+
+              echo "------------------------------------------------------------"
+              echo "set image"
+              echo "------------------------------------------------------------"
+              kubectl set image --namespace=$__FINC_K8S_NAMESPACE deployment/$dep $target_container_images --dry-run=$DRY_RUN
+
+              echo "------------------------------------------------------------"
+              echo "rollout status"
+              echo "------------------------------------------------------------"
+              kubectl rollout status --namespace=$__FINC_K8S_NAMESPACE deployment/$dep --timeout=$WATCH_TIMEOUT
+
+              echo "------------------------------------------------------------"
+              echo "describe"
+              echo "------------------------------------------------------------"
+              kubectl describe --namespace=$__FINC_K8S_NAMESPACE deployment/$dep
+            done
+      - run:
+          when: on_fail
+          name: "Rollback deployment resources"
+          command: |
+            for dep in ${__FINC_K8S_TARGET_DEPLOYMENTS[@]}; do
+              echo "============================================================"
+              echo "deployment: $dep"
+              echo "============================================================"
+              # Deployment resource names are kebab case, so they have to be converted to underscore for the shell arg names.
+              key_name="__FINC_BEFORE_DEPLOYMENT_REVISION_OF_${dep//-/_}"
+              rev=${!key_name}
+              target="deployment/$dep"
+
+              if [ -z "$rev" ]; then
+                echo "[WARN] unknown before revision"
+                exit
+              fi
+
+              CURRENT_REVISION=$(kubectl get -n "$__FINC_K8S_NAMESPACE" "$target" -o=jsonpath='{.metadata.annotations.deployment\.kubernetes\.io/revision}')
+              if [[ -n "$target" && "$rev" != "$CURRENT_REVISION" ]]; then
+                echo "rollback $target to revision: $rev"
+                kubectl rollout undo "$target" -n "$__FINC_K8S_NAMESPACE" --to-revision=$rev
+              else
+                echo "It is unnecessary to rollback because the current and before-deployment revisons are the same."
+              fi
+            done
 
   db-migration:
     description: |


### PR DESCRIPTION
# Issue
circleciで複数のdeployemntリソース(shoryuken, sidekiqなど)のimageを更新するためのコマンドを追加しました

# How to use
追記したexampleの通りですが、以下のように設定します (f4dx-serverの例)

```yaml
  deploy-k8s-stg:
    executor: aws-cli/default
    steps:
      - checkout
      - setenv
      - aws-cli/install
      - kube-orb/install-kubectl
      - kube-orb/install-kubeconfig:
          kubeconfig: KUBECONFIG_STAGING_DATA
      - finc-k8s/db-migration:
          namespace: f4dx-server
          migration-pod-for: f4dx-server
          job-image: ${IMAGE_NAME}
      - finc-k8s/update-container-images:
          container-image-updates: ${IMAGE_NAME}
          namespace: f4dx-server
          watch-timeout: 5m # NOTE: timeoutに関しては要検討 image pullの時間が結構掛かるはず
          deployment-target: stable
      - slack/status:
          fail_only: true
          include_visit_job_action: true
          failure_message: ":face_vomiting: k8sへのデプロイが失敗したのでジョブを確認してください"
          webhook: "$SRE_SLACK_WEBHOOK"
```

# Working example
deployが成功するときの例
https://app.circleci.com/pipelines/github/FiNCDeveloper/f4dx_server/1017/workflows/710ac560-a881-4288-95fa-43a0772c6e4b/jobs/1474

deployが失敗するときの例
https://app.circleci.com/pipelines/github/FiNCDeveloper/f4dx_server/1016/workflows/d7ce9889-2e86-450a-86e4-d19fe14403d7/jobs/1471


# How it works
1. 開始時にlabelに紐づくdeploymentのrevision番号を取得して`$BASH_ENV`に保存しておく
2. 対応するdeploymentに対してset imageで新しいimageを設定する
3. 失敗した場合、開始時に取得したrevision番号と同じなるように対象のdeploymentに対してrollout undoを行う。

複数のコンテナimageを指定したい時:
アプリケーションサーバーだけnginxと共存するなど、複数のコンテナを指定したい場合は `container1:latest nginx:latest` の形式で複数指定する。
対象のdeploymentを更新する前に、与えられたimageの組み合わせのうち、tagを除いたimage名からリソースに含まれるcontainer名を取り出し、`container_name=image_name` の形式を作成する。
作成した文字を用いて、`kubectl set image` で適用する。

# Related
サービス側のCI
https://github.com/FiNCDeveloper/f4dx_server/pull/243