### PR TITLE
Set images to cronjobs

### DIFF
--- a/k8s/CHANGELOG.md
+++ b/k8s/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Update `db-migration` command to use `--server-side` option by default.
 
+### BREAKING CHANGES
+
+- Rename `update-container-images` to `update-deployment-images`.
+
 ## [1.0.0] - 2021-03-31
 
 ### Added

--- a/k8s/CHANGELOG.md
+++ b/k8s/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Update `db-migration` command to use `--server-side` option by default.
+- Add `update-workload-resource-images` command to update all cronjobs' images or jobs' images.
 
 ### BREAKING CHANGES
 

--- a/k8s/CHANGELOG.md
+++ b/k8s/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Update `db-migration` command to use `--server-side` option by default.
-- Add `update-workload-resource-images` command to update all cronjobs' images or jobs' images.
+- Add `update-batch-resource-images` command to update all cronjobs' images or jobs' images.
 
 ### BREAKING CHANGES
 

--- a/k8s/orb.yaml
+++ b/k8s/orb.yaml
@@ -135,6 +135,101 @@ commands:
               fi
             done
 
+  update-workload-resource-images:
+    description: |
+      Updates all existing container images of the given workload type resources on the cluster by using the `kubectl set image` command.
+      For deployments, use the update-deployment-images command for the rollback support.
+      Requirements:
+        - kubeconfig should be configured to connect to the cluster.
+    parameters:
+      container-image-updates:
+        type: string
+        description: |
+          Specify a list of container image updates in the space-delimited format.
+          (e.g. ruby:latest your_repository.example.com/foo:bar)
+      namespace:
+        type: string
+        description: |
+          The kubernetes namespace that should be used.
+        default: ""
+      workload-resource-type:
+        type: string
+        description: |
+          Specify the target workload resource type.
+          See: https://kubernetes.io/docs/concepts/workloads
+        enum: ["cronjob", "job"]
+      dry-run:
+        description: |
+          Specify the dry-run strategy that the `kubectl set image` command will be executed with.
+          See: https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#-em-image-em-
+        type: enum
+        enum: ["none", "client", "server"]
+        default: "none"
+    steps:
+      - jq/install
+      - run:
+          name: "Update workload resource images"
+          description: "Update container images by using the `kubectl set image`. Filter given container names before updating images."
+          command: |
+            # NOTE:
+            # Naming rule basics: namespace, deployment name is repository name converted to kebab-case.
+            K8S_NAMESPACE="<< parameters.namespace >>"
+            if [ -z "$K8S_NAMESPACE" ]; then
+              K8S_NAMESPACE=${CIRCLE_PROJECT_REPONAME//_/-}
+            fi
+
+            workload_resource_type="<< parameters.workload-resource-type >>"
+
+            tareget_resources=($(kubectl get -n "$K8S_NAMESPACE" "$workload_resource_type" -o=jsonpath='{.items[*].metadata.name}'))
+
+            case $workload_resource_type in
+              "cronjob")
+                spec_path=".spec.jobTemplate.spec.template.spec"
+                ;;
+              "job")
+                spec_path=".spec.template.spec"
+                ;;
+              *)
+                echo "workload-resource-type is unknown. Please update the orb command if it is a valid workload resource."
+                exit 1;
+            esac
+
+            container_image_updates=($(echo "<< parameters.container-image-updates >>"))
+
+            DRY_RUN="<< parameters.dry-run >>"
+
+            for resource in ${tareget_resources[@]}; do
+              echo "============================================================"
+              echo "$workload_resource_type: $resource"
+              echo "============================================================"
+              # Build a new container_name=image pairs from the provided values to match the container image names in the target deployment resource.
+              pod_spec=$(kubectl get --namespace="$K8S_NAMESPACE" "$workload_resource_type"/"$resource" -o jsonpath --template "{$spec_path}")
+
+              for image in ${container_image_updates[@]}; do
+                repository=$(echo "$image" | awk -F ':' '{ print $1 }')
+                container_name=$(echo "$pod_spec" | jq -r --arg repository $repository '.containers[] | select(.image | startswith($repository)) | .name')
+                if [ -n "$container_name" ]; then
+                  set -- "$@" "${container_name}=${image}"
+                fi
+              done
+
+              echo "------------------------------------------------------------"
+              echo "set image"
+              echo "------------------------------------------------------------"
+              set -x
+              kubectl set image --namespace="$K8S_NAMESPACE" "$workload_resource_type"/"$resource" "$@" --dry-run="$DRY_RUN"
+              { set +x; } 2>/dev/null
+
+              echo "------------------------------------------------------------"
+              echo "describe"
+              echo "------------------------------------------------------------"
+              set -x
+              kubectl describe --namespace="$K8S_NAMESPACE" "$workload_resource_type"/"$resource"
+              { set +x; } 2>/dev/null
+
+              set --
+            done
+
   db-migration:
     description: |
       DB migration from kubernetes job.
@@ -278,6 +373,27 @@ examples:
                 namespace: example
                 watch-timeout: 5m
                 deployment-target: stable
+
+  update-workload-resource-images:
+    description: |
+      Update images on the given kubernetes resource.
+    usage:
+      version: 2.1
+      orbs:
+        finc-k8s: finc/k8s@x.y.z
+        kube-orb: circleci/kubernetes@x.y.z
+      jobs:
+        build:
+          docker:
+            - image: circleci/golang:x.y
+          steps:
+            - kube-orb/install-kubectl
+            - kube-orb/install-kubeconfig:
+                kubeconfig: KUBECONFIG_STAGING_DATA
+            - finc-k8s/update-workload-resource-images:
+                container-image-updates: golang:latest your_repository.example.com/foo:bar
+                namespace: example
+                workload-resource-type: cronjob
 
   db-migration:
     description: |

--- a/k8s/orb.yaml
+++ b/k8s/orb.yaml
@@ -214,14 +214,14 @@ commands:
               done
 
               echo "------------------------------------------------------------"
-              echo "set image"
+              echo "set image: $resource"
               echo "------------------------------------------------------------"
               set -x
               kubectl set image --namespace="$K8S_NAMESPACE" "$batch_resource_type"/"$resource" "$@" --dry-run="$DRY_RUN"
               { set +x; } 2>/dev/null
 
               echo "------------------------------------------------------------"
-              echo "describe"
+              echo "describe: $resource"
               echo "------------------------------------------------------------"
               set -x
               kubectl describe --namespace="$K8S_NAMESPACE" "$batch_resource_type"/"$resource"

--- a/k8s/orb.yaml
+++ b/k8s/orb.yaml
@@ -7,9 +7,9 @@ orbs:
   jq: circleci/jq@2.2.0
 
 commands:
-  update-container-images:
+  update-deployment-images:
     description: |
-      Updates existing container images of resources matched with the given target label on the cluster using the `kubectl set image` command.
+      Updates existing container images of deployments matched with the given target label on the cluster using the `kubectl set image` command.
       If any of them fails to update then rollback the deployment resources.
       Requirements:
         - kubeconfig should be configured to connect to the cluster.

--- a/k8s/orb.yaml
+++ b/k8s/orb.yaml
@@ -42,7 +42,7 @@ commands:
     steps:
       - jq/install
       - run:
-          name: "Prepare image update"
+          name: "Prepare deployment image update"
           description: "Get namespace for the later steps."
           command: |
             # NOTE:
@@ -67,7 +67,7 @@ commands:
               echo "export __FINC_BEFORE_DEPLOYMENT_REVISION_OF_${dep//-/_}=$(kubectl get -n $__FINC_K8S_NAMESPACE deployment/$dep -o=jsonpath='{.metadata.annotations.deployment\.kubernetes\.io/revision}')" >> $BASH_ENV
             done
       - run:
-          name: "Update container images"
+          name: "Update deployment container images"
           description: "Update container images by using the `kubectl set image`. Filter given container names before updating deployment images."
           command: |
             container_image_updates=($(echo "<< parameters.container-image-updates >>"))

--- a/k8s/orb.yaml
+++ b/k8s/orb.yaml
@@ -48,7 +48,7 @@ commands:
             # NOTE:
             # Naming rule basics: namespace, deployment name is repository name converted to kebab-case.
             K8S_NAMESPACE="<< parameters.namespace >>"
-            if [ -z "K8S_NAMESPACE" ]; then
+            if [ -z "$K8S_NAMESPACE" ]; then
               K8S_NAMESPACE=${CIRCLE_PROJECT_REPONAME//_/-}
             fi
             echo "export __FINC_K8S_NAMESPACE=${K8S_NAMESPACE}" >> $BASH_ENV

--- a/k8s/orb.yaml
+++ b/k8s/orb.yaml
@@ -135,9 +135,9 @@ commands:
               fi
             done
 
-  update-workload-resource-images:
+  update-batch-resource-images:
     description: |
-      Updates all existing container images of the given workload type resources on the cluster by using the `kubectl set image` command.
+      Updates all existing container images of the given batch type resources on the cluster by using the `kubectl set image` command.
       For deployments, use the update-deployment-images command for the rollback support.
       Requirements:
         - kubeconfig should be configured to connect to the cluster.
@@ -152,11 +152,11 @@ commands:
         description: |
           The kubernetes namespace that should be used.
         default: ""
-      workload-resource-type:
+      batch-resource-type:
         type: string
         description: |
-          Specify the target workload resource type.
-          See: https://kubernetes.io/docs/concepts/workloads
+          Specify the target batch resource type.
+          See: https://kubernetes.io/docs/concepts/workloads/controllers/job/
         enum: ["cronjob", "job"]
       dry-run:
         description: |
@@ -168,7 +168,7 @@ commands:
     steps:
       - jq/install
       - run:
-          name: "Update workload resource images"
+          name: "Update batch resource images"
           description: "Update container images by using the `kubectl set image`. Filter given container names before updating images."
           command: |
             # NOTE:
@@ -178,11 +178,11 @@ commands:
               K8S_NAMESPACE=${CIRCLE_PROJECT_REPONAME//_/-}
             fi
 
-            workload_resource_type="<< parameters.workload-resource-type >>"
+            batch_resource_type="<< parameters.batch-resource-type >>"
 
-            tareget_resources=($(kubectl get -n "$K8S_NAMESPACE" "$workload_resource_type" -o=jsonpath='{.items[*].metadata.name}'))
+            tareget_resources=($(kubectl get -n "$K8S_NAMESPACE" "$batch_resource_type" -o=jsonpath='{.items[*].metadata.name}'))
 
-            case $workload_resource_type in
+            case $batch_resource_type in
               "cronjob")
                 spec_path=".spec.jobTemplate.spec.template.spec"
                 ;;
@@ -190,7 +190,7 @@ commands:
                 spec_path=".spec.template.spec"
                 ;;
               *)
-                echo "workload-resource-type is unknown. Please update the orb command if it is a valid workload resource."
+                echo "unknown batch-resource-type"
                 exit 1;
             esac
 
@@ -200,10 +200,10 @@ commands:
 
             for resource in ${tareget_resources[@]}; do
               echo "============================================================"
-              echo "$workload_resource_type: $resource"
+              echo "$batch_resource_type: $resource"
               echo "============================================================"
               # Build a new container_name=image pairs from the provided values to match the container image names in the target deployment resource.
-              pod_spec=$(kubectl get --namespace="$K8S_NAMESPACE" "$workload_resource_type"/"$resource" -o jsonpath --template "{$spec_path}")
+              pod_spec=$(kubectl get --namespace="$K8S_NAMESPACE" "$batch_resource_type"/"$resource" -o jsonpath --template "{$spec_path}")
 
               for image in ${container_image_updates[@]}; do
                 repository=$(echo "$image" | awk -F ':' '{ print $1 }')
@@ -217,14 +217,14 @@ commands:
               echo "set image"
               echo "------------------------------------------------------------"
               set -x
-              kubectl set image --namespace="$K8S_NAMESPACE" "$workload_resource_type"/"$resource" "$@" --dry-run="$DRY_RUN"
+              kubectl set image --namespace="$K8S_NAMESPACE" "$batch_resource_type"/"$resource" "$@" --dry-run="$DRY_RUN"
               { set +x; } 2>/dev/null
 
               echo "------------------------------------------------------------"
               echo "describe"
               echo "------------------------------------------------------------"
               set -x
-              kubectl describe --namespace="$K8S_NAMESPACE" "$workload_resource_type"/"$resource"
+              kubectl describe --namespace="$K8S_NAMESPACE" "$batch_resource_type"/"$resource"
               { set +x; } 2>/dev/null
 
               set --
@@ -374,7 +374,7 @@ examples:
                 watch-timeout: 5m
                 deployment-target: stable
 
-  update-workload-resource-images:
+  update-batch-resource-images:
     description: |
       Update images on the given kubernetes resource.
     usage:
@@ -390,10 +390,10 @@ examples:
             - kube-orb/install-kubectl
             - kube-orb/install-kubeconfig:
                 kubeconfig: KUBECONFIG_STAGING_DATA
-            - finc-k8s/update-workload-resource-images:
+            - finc-k8s/update-batch-resource-images:
                 container-image-updates: golang:latest your_repository.example.com/foo:bar
                 namespace: example
-                workload-resource-type: cronjob
+                batch-resource-type: cronjob
 
   db-migration:
     description: |


### PR DESCRIPTION
# Issue
- cronjobをupdateするための `update-batch-resource-images` コマンドを追加した
- 既存のupdate-contianer-imagesのコマンド名をupdate-deployment-imagesに変更した (実質deploymentしかサポートしていないのと追加したコマンドと類似して分かりづらいので明確化する)

# Concept
- batch-resource-typeで指定されたresourceをすべて指定されたimageで置き換える
- imageの置き換えは既存のdeploymentの更新と同じくimageのrepository名が同じリソースに対して `kubectl set image` する。
- 今後jobもEKSに対応させていくはずなので、batch-resource-typeはcronjobとjobを受け取ることを想定している

# How to use
```yaml
      version: 2.1
      orbs:
        finc-k8s: finc/k8s@x.y.z
        kube-orb: circleci/kubernetes@x.y.z
      jobs:
        build:
          docker:
            - image: circleci/golang:x.y
          steps:
            - kube-orb/install-kubectl
            - kube-orb/install-kubeconfig:
                kubeconfig: KUBECONFIG_STAGING_DATA
            - finc-k8s/update-batch-resource-images:
                container-image-updates: golang:latest your_repository.example.com/foo:bar
                namespace: example
                batch-resource-type: cronjob
```

# Example
- grouperで試した例: https://github.com/FiNCDeveloper/grouper/pull/1583
(reviewで指摘されたcommandのrename を反映する前です)


# To Reviewer
- update-batch-resource-imagesのインタフェースは適切か
- commandのrenameは適切か 
  - update-container-imagesとupdate-batch-resource-imagesの2つが存在することになってわかりづらいのでrenameしました

# NOTE
dev版のcronjob
```
➜  circleci orb info finc/k8s@dev:cronjob

Latest: finc/k8s@1.0.0
Last-updated: 2021-04-01T09:53:14.161Z
Created: 2020-09-28T06:38:13.285Z
Total-revisions: 11

Total-commands: 3
Total-executors: 0
Total-jobs: 0

## Statistics (30 days):
Builds: 2244
Projects: 40
Orgs: 1

Learn more about this orb online in the CircleCI Orb Registry:
https://circleci.com/developer/orbs/orb/finc/k8s
```
